### PR TITLE
Handle null terminators & fix leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 *.x86_64
 *.hex
 deps/
+test

--- a/decode.c
+++ b/decode.c
@@ -24,7 +24,7 @@ uri_decode (const char *src) {
   len = strlen(src);
 
   // alloc
-  dec = (char *) malloc(len);
+  dec = (char *) malloc(len + 1);
 
 #define push(c) (dec[size++] = c)
 

--- a/encode.c
+++ b/encode.c
@@ -76,7 +76,7 @@ uri_encode (const char *src) {
   }
 
   // alloc with probable size
-  enc = (char *) malloc(sizeof(char) * msize);
+  enc = (char *) malloc((sizeof(char) * msize) + 1);
   if (NULL == enc) { return NULL; }
 
   // reset

--- a/test.c
+++ b/test.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <ok/ok.h>
@@ -13,11 +14,13 @@
 #include "uri.h"
 
 #define S(x) # x
-#define t(m, a, b) ({ \
-    char tmp[1024]; \
+#define t(m, a, b) ({                              \
+    char tmp[1024];                                \
     sprintf(tmp, "%s(%s) = %s", S(m), S(a), S(b)); \
-    assert(0 == strcmp(b, (char *) m(a))); \
-    ok(tmp); \
+    char *result = m(a);                           \
+    assert(0 == strcmp(b, result));                \
+    ok(tmp);                                       \
+    free(result);                                  \
 })
 
 int


### PR DESCRIPTION
Had some really weird behaviour trying to use this in our http lib.  Turns out, we weren't handling the `\0` :/
